### PR TITLE
Adding handling of cases where the first milestone type is GAME_WARMUP

### DIFF
--- a/mlbv/mlbam/mlbstream.py
+++ b/mlbv/mlbam/mlbstream.py
@@ -256,6 +256,9 @@ def _lookup_inning_timestamp_via_milestones(
                 elif str(keyword["name"]) == "top":
                     if str(keyword["value"]) != "true":
                         milestone_inning_half = "bottom"
+        else:
+            continue
+            
         if milestone_inning == inning and milestone_inning_half == inning_half:
             # we found it
             inning_start_timestamp_str = milestone["absoluteTime"]


### PR DESCRIPTION
Thanks for your hard work on keeping this library up to date! I just made a small tweak to the mlbstream.py file, as if the first element in _milestones_ has a _milestoneType_ value of **GAME_WARMUP** it throws things off, since it doesn't meet any of the if/elif criteria here:

```    for milestone in milestones:
        if milestone["milestoneType"] == "STREAM_START":
            milestone_inning = False
            stream_start_str = str(milestone["absoluteTime"]
)
            stream_start = parser.parse(stream_start_str).timestamp()
        elif milestone["milestoneType"] == "BROADCAST_START":
            milestone_inning = "0"
            milestone_inning_half = "top"
            broadcast_start_str = str(milestone["absoluteTime"])
            broadcast_start = parser.parse(stream_start_str).timestamp()
        elif milestone["milestoneType"] == "INNING_START":
            milestone_inning = "1"
            milestone_inning_half = "top"
            for keyword in milestone["keywords"]:
                if str(keyword["name"]) == "inning":
                    milestone_inning = str(keyword["value"])
                elif str(keyword["name"]) == "top":
                    if str(keyword["value"]) != "true":
                        milestone_inning_half = "bottom"```