### PR TITLE
Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = ["CHANGELOG.md", "README.md", "config.template", "mlbv-fzf"]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 requests = "^2.25.1"
-streamlink = "^6.1.0"
+streamlink = "^8.2.1"
 lxml = "^6.0.2"
 python-dateutil = "^2.8.1"
 flake8 = "^3.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = ["CHANGELOG.md", "README.md", "config.template", "mlbv-fzf"]
 python = ">=3.8,<4.0"
 requests = "^2.25.1"
 streamlink = "^6.1.0"
-lxml = "^5.3.1"
+lxml = "^6.0.2"
 python-dateutil = "^2.8.1"
 flake8 = "^3.9.2"
 pytz = "^2023.3.post1"


### PR DESCRIPTION
The previous lxml version was not compatible with Python 3.14 and then the previous streamlink version was not compatible with the newest lxml version.

I tested with a condensed game from last season and it worked. I don't have a MLB.TV subscription right now, so can't test with a full game.